### PR TITLE
Elixir 1.6 is enough

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule LocaleNames.MixProject do
     [
       app: :locale_names,
       version: "0.1.0",
-      elixir: "~> 1.7",
+      elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: dialyzer()


### PR DESCRIPTION
Avoid this kind of warning `warning: the dependency :locale_names requires Elixir "~> 1.7" but you are running on v1.6.5`