### PR TITLE
Limits which files are included for Hex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,8 @@ defmodule LocaleNames.MixProject do
         "priv/cldr-core/scriptMetadata.json",
         "priv/cldr-core/supplemental/languageData.json",
         "priv/cldr-core/supplemental/likelySubtags.json",
-        "priv/cldr-localenames-full/main",
+        "priv/cldr-localenames-full/main/**/languages.json",
+        "priv/cldr-localenames-full/main/**/territories.json",
         "README*"
       ],
       licenses: ["MIT"],


### PR DESCRIPTION
The size limit is 8mb (https://github.com/hexpm/hex/issues/566)
and the cld-localenames-full directory is at 28mb