### PR TITLE
Add a deprecation warning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,3 +57,8 @@ jobs:
       - run: mix dialyzer --halt-exit-status
       - store_test_results:
           path: _build/test/lib/locale_names
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,7 @@ Before submitting a Pull Request, please ensure the following:
 ```
 $ git clone https://github.com/fewlinesco/locale_names.git
 $ cd locale_names
+$ git submodule update --init
 $ mix deps.get
 $ mix test
 ```

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CircleCI](https://circleci.com/gh/fewlinesco/locale_names.svg?style=svg)](https://circleci.com/gh/fewlinesco/locale_names)
 
+:warning: This library is no more maintained as we don't use it anymore. :warning:
+
 This library provides functions for knowing:
 
 - How is a locale spelled in its own language (`en-US` is "American English", `fr-CA` is "Français canadien")


### PR DESCRIPTION
This PR adds a warning for deprecation as we won't maintain this lib anymore.

It also fix a forgotten line in `CONTRIBUTING.md` (if someone wanted to fork it)